### PR TITLE
Fixed count and filtering closure problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Database is available at `C:\Users\%USERPROFILE%\AppData\Roaming\numpuk3\values.
 - [Inifinite loop when saving an object from async await](https://stackoverflow.com/questions/61717644/inifinite-loop-when-saving-an-object-from-async-await)
 - [React hooks... Oops! Part 2 - why does my effect run multiple times with the same dependencies?](https://lukaszmakuch.pl/post/react-hooks-oops-part-2-effect-runs-multiple-times-with-the-same-dependencies/)
 - [You’re overusing useMemo: Rethinking Hooks memoization](https://blog.logrocket.com/rethinking-hooks-memoization/)
+- [React.memo problem example](https://codesandbox.io/s/determined-liskov-hxzw0?file=/src/Toggle.jsx)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Database is available at `C:\Users\%USERPROFILE%\AppData\Roaming\numpuk3\values.
 
 - [Dealing with infinite loops in useEffect hook](https://dev.to/webcoderkz/dealing-with-infinite-loops-in-useeffect-hook-j11)
 - [Inifinite loop when saving an object from async await](https://stackoverflow.com/questions/61717644/inifinite-loop-when-saving-an-object-from-async-await)
+- [React memo closure problem example](https://stackoverflow.com/questions/61779826/why-the-props-that-are-passed-to-memo-are-dont-store-the-value)
 - [React hooks... Oops! Part 2 - why does my effect run multiple times with the same dependencies?](https://lukaszmakuch.pl/post/react-hooks-oops-part-2-effect-runs-multiple-times-with-the-same-dependencies/)
 - [You’re overusing useMemo: Rethinking Hooks memoization](https://blog.logrocket.com/rethinking-hooks-memoization/)
-- [React.memo problem example](https://codesandbox.io/s/determined-liskov-hxzw0?file=/src/Toggle.jsx)

--- a/src/+services/examinationReader.js
+++ b/src/+services/examinationReader.js
@@ -16,7 +16,7 @@ export const getExaminations = async (
     pagination
   );
 
-  const count = await getExaminationsCountAsync();
+  const count = await getExaminationsCountAsync(findQuery);
 
   return { examinations, count };
 };
@@ -40,9 +40,9 @@ const getExaminationsAsync = (projection, findQuery, pagination) => {
   });
 };
 
-const getExaminationsCountAsync = () => {
+const getExaminationsCountAsync = (query) => {
   return new Promise((resolve, reject) => {
-    db.count({}, (err, count) => {
+    db.count(query, (err, count) => {
       if (err) {
         logger.error(err);
         reject(err);

--- a/src/examinations/table/ExaminationTable.jsx
+++ b/src/examinations/table/ExaminationTable.jsx
@@ -4,24 +4,26 @@ import Table from "@material-ui/core/Table";
 import { TableHeader } from "./+components/TableHeader";
 import { TableRows } from "./+components/TableRows";
 
-export const ExaminationTable = React.memo(
-  ({ examinations, metadataColumns, testColumns }) => {
-    const testColumnsArray = mapToArray(testColumns);
-    return (
-      <Table size="small" stickyHeader>
-        <TableHeader
-          metadataColumns={metadataColumns}
-          testColumns={testColumnsArray}
-        />
-        <TableRows
-          examinations={examinations}
-          metadataColumns={metadataColumns}
-          testColumns={testColumnsArray}
-        />
-      </Table>
-    );
-  }
-);
+export const ExaminationTable = ({
+  examinations,
+  metadataColumns,
+  testColumns,
+}) => {
+  const testColumnsArray = mapToArray(testColumns);
+  return (
+    <Table size="small" stickyHeader>
+      <TableHeader
+        metadataColumns={metadataColumns}
+        testColumns={testColumnsArray}
+      />
+      <TableRows
+        examinations={examinations}
+        metadataColumns={metadataColumns}
+        testColumns={testColumnsArray}
+      />
+    </Table>
+  );
+};
 
 const mapToArray = (sourceObject) =>
   Object.keys(sourceObject).filter((key) => sourceObject[key]);

--- a/src/examinations/visibility/+components/Filter.jsx
+++ b/src/examinations/visibility/+components/Filter.jsx
@@ -37,11 +37,9 @@ const FilterComponent = ({
   );
 };
 
-export const Filter = React.memo(FilterComponent);
+export const Filter = React.memo(FilterComponent, areEqual);
 
 function areEqual(prevProps, nextProps) {
-  // console.log(prevProps);
-  // console.log(nextProps);
   const hasVisibilityNotChanged = prevProps.isVisible === nextProps.isVisible;
   const hasFiltersNotChanged = prevProps.isFiltered === nextProps.isFiltered;
   return hasVisibilityNotChanged && hasFiltersNotChanged;

--- a/src/examinations/visibility/+components/Filter.jsx
+++ b/src/examinations/visibility/+components/Filter.jsx
@@ -40,6 +40,8 @@ const FilterComponent = ({
 export const Filter = React.memo(FilterComponent, areEqual);
 
 function areEqual(prevProps, nextProps) {
+  // console.log(prevProps);
+  // console.log(nextProps);
   const hasVisibilityNotChanged = prevProps.isVisible === nextProps.isVisible;
   const hasFiltersNotChanged = prevProps.isFiltered === nextProps.isFiltered;
   return hasVisibilityNotChanged && hasFiltersNotChanged;

--- a/src/examinations/visibility/+components/Filter.jsx
+++ b/src/examinations/visibility/+components/Filter.jsx
@@ -37,7 +37,7 @@ const FilterComponent = ({
   );
 };
 
-export const Filter = React.memo(FilterComponent, areEqual);
+export const Filter = React.memo(FilterComponent);
 
 function areEqual(prevProps, nextProps) {
   // console.log(prevProps);

--- a/src/examinations/visibility/+components/FiltersList.jsx
+++ b/src/examinations/visibility/+components/FiltersList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Grid from "@material-ui/core/Grid";

--- a/src/examinations/visibility/+components/FiltersList.jsx
+++ b/src/examinations/visibility/+components/FiltersList.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Grid from "@material-ui/core/Grid";
@@ -17,42 +17,42 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const FiltersList = ({ visibility, setVisibility }) => {
-  const [filters, setFilters] = useState({});
+export const FiltersList = ({
+  visibility,
+  setVisibility,
+  filters,
+  setFilters,
+}) => {
   const { t } = useTranslation("n3_metadata");
-  console.log(filters);
   const classes = useStyles();
 
-  const handleChange = (name, value) => {
-    setVisibility({
-      ...visibility,
-      [name]: value,
-    });
-  };
-
-  const handleFilterChange = (name, value) => {
-    console.log("Im here");
-    console.log(value);
-    if (value === undefined) {
-      console.log("Value undefined");
-      console.log(filters);
-      const copy = { ...filters };
-      delete copy[name];
-      console.log(copy);
-      setFilters(copy);
-    } else {
-      console.log("Value else");
-      console.log(filters);
-      const cop = {
-        ...filters,
+  const handleChange = useCallback(
+    (name, value) => {
+      setVisibility((prevState) => ({
+        ...prevState,
         [name]: value,
-      };
-      console.log(cop);
-      setFilters(cop);
-    }
-  };
+      }));
+    },
+    [setVisibility]
+  );
 
-  // console.log(filters);
+  const handleFilterChange = useCallback(
+    (name, value) => {
+      setFilters((prevState) => {
+        if (value === undefined) {
+          const copy = { ...prevState };
+          delete copy[name];
+          return copy;
+        } else {
+          return {
+            ...prevState,
+            [name]: value,
+          };
+        }
+      });
+    },
+    [setFilters]
+  );
 
   return (
     <Grid item xs={6}>

--- a/src/examinations/visibility/+components/FiltersList.jsx
+++ b/src/examinations/visibility/+components/FiltersList.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Grid from "@material-ui/core/Grid";
@@ -17,50 +17,60 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const FiltersList = React.memo(
-  ({ visibility, setVisibility, filters, setFilters }) => {
-    const { t } = useTranslation("n3_metadata");
+export const FiltersList = ({ visibility, setVisibility }) => {
+  const [filters, setFilters] = useState({});
+  const { t } = useTranslation("n3_metadata");
+  console.log(filters);
+  const classes = useStyles();
 
-    const classes = useStyles();
+  const handleChange = (name, value) => {
+    setVisibility({
+      ...visibility,
+      [name]: value,
+    });
+  };
 
-    const handleChange = (name, value) => {
-      setVisibility({
-        ...visibility,
+  const handleFilterChange = (name, value) => {
+    console.log("Im here");
+    console.log(value);
+    if (value === undefined) {
+      console.log("Value undefined");
+      console.log(filters);
+      const copy = { ...filters };
+      delete copy[name];
+      console.log(copy);
+      setFilters(copy);
+    } else {
+      console.log("Value else");
+      console.log(filters);
+      const cop = {
+        ...filters,
         [name]: value,
-      });
-    };
+      };
+      console.log(cop);
+      setFilters(cop);
+    }
+  };
 
-    const handleFilterChange = (name, value) => {
-      if (value === undefined) {
-        const copy = { ...filters };
-        delete copy[name];
-        setFilters(copy);
-      } else {
-        setFilters({
-          ...filters,
-          [name]: value,
-        });
-      }
-    };
+  // console.log(filters);
 
-    return (
-      <Grid item xs={6}>
-        <Paper className={classes.paper}>
-          <FormGroup>
-            {Object.keys(visibility).map((objectKey) => (
-              <Filter
-                t={t}
-                key={objectKey}
-                objectKey={objectKey}
-                isVisible={visibility[objectKey]}
-                onVisibilityChange={handleChange}
-                isFiltered={filters[objectKey]}
-                onFilterChange={handleFilterChange}
-              />
-            ))}
-          </FormGroup>
-        </Paper>
-      </Grid>
-    );
-  }
-);
+  return (
+    <Grid item xs={6}>
+      <Paper className={classes.paper}>
+        <FormGroup>
+          {Object.keys(visibility).map((objectKey) => (
+            <Filter
+              t={t}
+              key={objectKey}
+              objectKey={objectKey}
+              isVisible={visibility[objectKey]}
+              onVisibilityChange={handleChange}
+              isFiltered={filters[objectKey]}
+              onFilterChange={handleFilterChange}
+            />
+          ))}
+        </FormGroup>
+      </Paper>
+    </Grid>
+  );
+};

--- a/src/examinations/visibility/+components/LabelSwitch.jsx
+++ b/src/examinations/visibility/+components/LabelSwitch.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
 
-export const LabelSwitch = ({ isVisible, label, name, handleChange }) => {
+export const LabelSwitch2 = ({ isVisible, label, name, handleChange }) => {
   return (
     <FormControlLabel
       control={
@@ -12,3 +12,5 @@ export const LabelSwitch = ({ isVisible, label, name, handleChange }) => {
     />
   );
 };
+
+export const LabelSwitch = React.memo(LabelSwitch2);

--- a/src/examinations/visibility/+components/ThreeStateCheckbox.jsx
+++ b/src/examinations/visibility/+components/ThreeStateCheckbox.jsx
@@ -17,7 +17,6 @@ export const ThreeStateCheckbox = ({ isChecked, isVisible, onChange }) => {
 
   return (
     <Checkbox
-      defaultChecked
       indeterminate={indeterminate}
       color="primary"
       checked={checked}

--- a/src/examinations/visibility/+components/VisibilityList.jsx
+++ b/src/examinations/visibility/+components/VisibilityList.jsx
@@ -35,6 +35,7 @@ export const VisibilityList = React.memo(({ visibility, setVisibility }) => {
         <FormGroup>
           {Object.keys(visibility).map((objectKey) => (
             <LabelSwitch
+              key={objectKey}
               label={t(objectKey)}
               handleChange={handleChange}
               name={objectKey}

--- a/src/examinations/visibility/+components/VisibilityList.jsx
+++ b/src/examinations/visibility/+components/VisibilityList.jsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const VisibilityList = React.memo(({ visibility, setVisibility }) => {
+export const VisibilityList = ({ visibility, setVisibility }) => {
   const { t } = useTranslation("n3_metadata");
 
   const classes = useStyles();
@@ -46,4 +46,4 @@ export const VisibilityList = React.memo(({ visibility, setVisibility }) => {
       </Paper>
     </Grid>
   );
-});
+};


### PR DESCRIPTION
Fixed #25 and #24 - memoization of the list caused an unexpected effect:
- the list switches list was reloaded with every click
- to avoid rerender of the whole list, I have used React.memo with areEqual function that controlled if the switch should actually be rerendered
- the list of state for the buttons was always in default, init state because the click handler kept the value in closure state
- this caused that only one button could be switch at one time

Solution:
- use the function way of updating state in useState that always gives access to previous state
- additionally the click handlers were wrapped with useCallback hook to avoid constant recreation of the hook
